### PR TITLE
fix: missing husky dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-browser-dynamic": "^17.3.0",
     "@angular/router": "^17.3.0",
     "flowbite": "^3.1.2",
+    "husky": "^9.1.7",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.3"


### PR DESCRIPTION
specific husky version is up to change, as version 9.1.7 was just picked by pnpm.