### PR TITLE
fix(image-upload): limit file input to its container

### DIFF
--- a/src/app/features/wishlist/pages/create-wishlist/create-wishlist.page.html
+++ b/src/app/features/wishlist/pages/create-wishlist/create-wishlist.page.html
@@ -22,7 +22,7 @@
 
   <div class="container-type-inline-size"></div>
   <form [formGroup]="form" (ngSubmit)="submit()" class="min-h-0">
-    <div class="px-4 py-3">
+    <div class="relative px-4 py-3">
       <div
         *ngIf="previewUrl; else placeholder"
         class="relative flex min-h-[218px] w-full cursor-pointer flex-col justify-end overflow-hidden rounded-lg bg-white bg-cover bg-center bg-no-repeat"


### PR DESCRIPTION
Prevented the file input from covering the entire screen by setting the parent div to relative.
